### PR TITLE
fix(lessons/navigation.md): reassigned key prop

### DIFF
--- a/lessons/navigation.md
+++ b/lessons/navigation.md
@@ -62,8 +62,8 @@ export default () => {
       <h1>Notes</h1>
 
       {notes.map(note => (
-        <div>
-          <Link key={note.id} href="/notes/[id]" as={`/notes/${note.id}`}>
+        <div key={note.id}>
+          <Link href="/notes/[id]" as={`/notes/${note.id}`}>
             <a>
               <strong>{note.title}</strong>
             </a>


### PR DESCRIPTION
Key prop on line #66 throws warning. This pr moves key prop to outermost element (div line #65) and resolves React warning.